### PR TITLE
fix: resolve ambiguous --index flag and invalid short flags in easy_gui.py

### DIFF
--- a/advanced_rvc_inference/app/easy_gui.py
+++ b/advanced_rvc_inference/app/easy_gui.py
@@ -247,21 +247,21 @@ def create_easy_app(theme=None):
 
                     index_path_arg = ""
                     if index_file and os.path.exists(index_file):
-                        index_path_arg = f' --index "{index_file}"'
+                        index_path_arg = f' --index_path "{index_file}"'
 
                     cmd = (
                         f'{python} {configs["convert_path"]}'
-                        f' -i "{input_audio}"'
-                        f' -m "{model_path}"'
-                        f' -p {int(pitch)}'
+                        f' --input_path "{input_audio}"'
+                        f' --pth_path "{model_path}"'
+                        f' --pitch {int(pitch)}'
                         f' --f0_method {f0_method_val}'
                         f' --index_rate {index_rate_val}'
                         f' --filter_radius {filter_radius_val}'
                         f' --rms_mix_rate {rms_mix_val}'
                         f' --protect {protect_val}'
                         f'{index_path_arg}'
-                        f' -f {export_format_val}'
-                        f' -o "{output_path}"'
+                        f' --export_format {export_format_val}'
+                        f' --output_path "{output_path}"'
                     )
 
                     _gr.Info("Starting voice conversion...")
@@ -394,7 +394,7 @@ def create_easy_app(theme=None):
 
                         index_path_arg = ""
                         if index_file and os.path.exists(index_file):
-                            index_path_arg = f' --index "{index_file}"'
+                            index_path_arg = f' --index_path "{index_file}"'
 
                         results = []
                         for i, audio_file in enumerate(audio_files, 1):
@@ -403,15 +403,15 @@ def create_easy_app(theme=None):
 
                             cmd = (
                                 f'{python} {configs["convert_path"]}'
-                                f' -i "{audio_file}"'
-                                f' -m "{model_path}"'
-                                f' -p {int(pitch)}'
+                                f' --input_path "{audio_file}"'
+                                f' --pth_path "{model_path}"'
+                                f' --pitch {int(pitch)}'
                                 f' --f0_method {f0_method_val}'
                                 f' --index_rate {index_rate_val}'
                                 f' --filter_radius {filter_radius_val}'
                                 f'{index_path_arg}'
-                                f' -f {export_format_val}'
-                                f' -o "{output_path}"'
+                                f' --export_format {export_format_val}'
+                                f' --output_path "{output_path}"'
                             )
 
                             result = subprocess.run(


### PR DESCRIPTION
## Bug Fix

Fixes the conversion failure in EasyGUI when an index file is provided.

### Problem
When using the EasyGUI convert (both single and batch), the subprocess command uses `--index` as a flag to pass the index file path to `convert.py`. However, `convert.py` argparse defines both `--index_rate` and `--index_path`, making the prefix `--index` **ambiguous**:

```
convert.py: error: ambiguous option: --index could match --index_rate, --index_path
```

Additionally, the short flags (`-i`, `-m`, `-p`, `-f`, `-o`) used in the subprocess commands are **never defined** in `convert.py` argparse, which would cause `unrecognized arguments` errors.

### Changes

In `advanced_rvc_inference/app/easy_gui.py`:

| Before | After | Why |
|--------|-------|-----|
| `--index` | `--index_path` | Ambiguous prefix — matches both `--index_rate` and `--index_path` |
| `-i` | `--input_path` | Short flag not defined in argparse |
| `-m` | `--pth_path` | Short flag not defined in argparse |
| `-p` | `--pitch` | Short flag not defined in argparse |
| `-f` | `--export_format` | Short flag not defined in argparse |
| `-o` | `--output_path` | Short flag not defined in argparse |

Both `easy_convert()` and `easy_batch_convert()` functions were fixed.

### Testing
The fix aligns the subprocess flags with the actual argument names defined in `convert.py` `parse_arguments()` (lines 40-74), ensuring no ambiguous or unrecognized argument errors.