### PR TITLE
Fix UnboundLocalError: grad_norm_g undefined during gradient accumulation

### DIFF
--- a/advanced_rvc_inference/rvc/train/training/train.py
+++ b/advanced_rvc_inference/rvc/train/training/train.py
@@ -831,6 +831,9 @@ def train_and_evaluate(rank, epoch, hps, nets, optims, scaler, train_loader, wri
         # Optimization: scale loss by accumulation steps for correct gradient averaging
         loss_gen_all_scaled = loss_gen_all * loss_scale_factor
 
+        # Initialize grad_norm_g so it's always defined (needed for gradient accumulation)
+        grad_norm_g = 0.0
+
         # Optimization: set_to_none=True is faster than zeroing gradients
         optim_g.zero_grad(set_to_none=True)
         if autocast_enabled:


### PR DESCRIPTION
## Problem

In `train_and_evaluate()`, `grad_norm_g` is only assigned inside conditional blocks that check `if (batch_idx + 1) % grad_accum_steps == 0 or (batch_idx + 1) == total_steps`. When gradient accumulation is enabled and the current batch is an intermediate accumulation step (not the last one), the optimizer step is skipped and `grad_norm_g` is never assigned.

However, line 853 unconditionally appends `grad_norm_g` to `avg_losses["grad_g_50"]`, which causes:

```
UnboundLocalError: cannot access local variable 'grad_norm_g' where it is not associated with a value
```

## Fix

Initialize `grad_norm_g = 0.0` before the generator optimizer block. On accumulation steps where the optimizer does not step, the gradient norm is recorded as `0.0` (a safe no-op for the running average).

## Root Cause

Gradient accumulation was added as an optimization but the logging code was not updated to handle the case where `grad_norm_g` is not computed on every batch.

## Affected File
- `advanced_rvc_inference/rvc/train/training/train.py`